### PR TITLE
Update color.d.ts

### DIFF
--- a/color.d.ts
+++ b/color.d.ts
@@ -119,3 +119,4 @@ declare module net.brehaut {
     function Color(color: ColorConstructorValue): Color;
 }
 
+export = net.brehaut.Colors;


### PR DESCRIPTION
Exporting the Color function avoid error TS2306 - File ... color-js/color.d.ts' is not a module when using systemjs as module loader in Angular 2 application with typescript 2.1